### PR TITLE
webgl-fundamentals - drawArrays pseudo code

### DIFF
--- a/webgl/lessons/webgl-fundamentals.md
+++ b/webgl/lessons/webgl-fundamentals.md
@@ -103,7 +103,7 @@ you could imagine it would be used like this
       var size = 4;
       for (var i = 0; i < count; ++i) {
          // copy the next 4 values from positionBuffer to the a_position attribute
-         const start = (offset + i) * stride;
+         const start = offset + i * stride;
          attributes.a_position = positionBuffer.slice(start, start + size);
          runVertexShader();
          ...


### PR DESCRIPTION
`offset + i * stride` rather than `(offset + i) * stride`?
`offset` is a "global" offset or am I wrong?