### PR TITLE
Properly handle devicePixelRatios like 1.25

### DIFF
--- a/webgl/lessons/webgl-resizing-the-canvas.md
+++ b/webgl/lessons/webgl-resizing-the-canvas.md
@@ -151,8 +151,8 @@ function resize(gl) {
   // Lookup the size the browser is displaying the canvas in CSS pixels
   // and compute a size needed to make our drawingbuffer match it in
   // device pixels.
-  var displayWidth  = Math.floor(gl.canvas.clientWidth  * realToCSSPixels);
-  var displayHeight = Math.floor(gl.canvas.clientHeight * realToCSSPixels);
+  var displayWidth  = Math.round(gl.canvas.clientWidth  * realToCSSPixels);
+  var displayHeight = Math.round(gl.canvas.clientHeight * realToCSSPixels);
 
   // Check if the canvas is not the same size.
   if (gl.canvas.width  !== displayWidth ||


### PR DESCRIPTION
Using **Math.floor**(gl.canvas.clientWidth  * realToCSSPixels) produces a different value than the browser (Chrome, at least) computes, when using a devicePixelRatio of 1.25 (e.g. Windows set to 125% display scaling), and yields a super-blurry canvas.  Using **Math.round** resolves the issue and looks correctly crisp on all browser and devices I tested on.