### PR TITLE
Fixed shadow rendering on safari

### DIFF
--- a/webgl/webgl-shadows-basic-w-bias.html
+++ b/webgl/webgl-shadows-basic-w-bias.html
@@ -233,6 +233,31 @@ function main() {
       depthTexture,         // texture
       0);                   // mip level
 
+  
+  //binding color component to framebuffer technically only necessary for safari
+  const color = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, color);
+  gl.texImage2D(
+          gl.TEXTURE_2D,
+          0,
+          gl.RGBA,
+          depthTextureSize,
+          depthTextureSize,
+          0,
+          gl.RGBA,
+          gl.UNSIGNED_BYTE,
+          null,
+  );
+
+  gl.framebufferTexture2D(
+          gl.FRAMEBUFFER,
+          gl.COLOR_ATTACHMENT0,
+          gl.TEXTURE_2D,
+          color,
+          0,
+  );
+  
+
   function degToRad(d) {
     return d * Math.PI / 180;
   }

--- a/webgl/webgl-shadows-basic.html
+++ b/webgl/webgl-shadows-basic.html
@@ -232,6 +232,30 @@ function main() {
       depthTexture,         // texture
       0);                   // mip level
 
+
+  //binding color component to framebuffer technically only necessary for safari
+  const color = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, color);
+  gl.texImage2D(
+          gl.TEXTURE_2D,
+          0,
+          gl.RGBA,
+          depthTextureSize,
+          depthTextureSize,
+          0,
+          gl.RGBA,
+          gl.UNSIGNED_BYTE,
+          null,
+  );
+
+  gl.framebufferTexture2D(
+          gl.FRAMEBUFFER,
+          gl.COLOR_ATTACHMENT0,
+          gl.TEXTURE_2D,
+          color,
+          0,
+  );
+
   function degToRad(d) {
     return d * Math.PI / 180;
   }

--- a/webgl/webgl-shadows-depth-texture.html
+++ b/webgl/webgl-shadows-depth-texture.html
@@ -229,6 +229,29 @@ function main() {
       depthTexture,         // texture
       0);                   // mip level
 
+  //binding color component to framebuffer technically only necessary for safari
+  const color = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, color);
+  gl.texImage2D(
+          gl.TEXTURE_2D,
+          0,
+          gl.RGBA,
+          depthTextureSize,
+          depthTextureSize,
+          0,
+          gl.RGBA,
+          gl.UNSIGNED_BYTE,
+          null,
+  );
+
+  gl.framebufferTexture2D(
+          gl.FRAMEBUFFER,
+          gl.COLOR_ATTACHMENT0,
+          gl.TEXTURE_2D,
+          color,
+          0,
+  );
+
   function degToRad(d) {
     return d * Math.PI / 180;
   }

--- a/webgl/webgl-shadows-w-directional-light.html
+++ b/webgl/webgl-shadows-w-directional-light.html
@@ -249,6 +249,29 @@ function main() {
       depthTexture,         // texture
       0);                   // mip level
 
+  //binding color component to framebuffer technically only necessary for safari
+  const color = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, color);
+  gl.texImage2D(
+          gl.TEXTURE_2D,
+          0,
+          gl.RGBA,
+          depthTextureSize,
+          depthTextureSize,
+          0,
+          gl.RGBA,
+          gl.UNSIGNED_BYTE,
+          null,
+  );
+
+  gl.framebufferTexture2D(
+          gl.FRAMEBUFFER,
+          gl.COLOR_ATTACHMENT0,
+          gl.TEXTURE_2D,
+          color,
+          0,
+  );
+
   function degToRad(d) {
     return d * Math.PI / 180;
   }

--- a/webgl/webgl-shadows-w-spot-light.html
+++ b/webgl/webgl-shadows-w-spot-light.html
@@ -281,6 +281,29 @@ function main() {
       depthTexture,         // texture
       0);                   // mip level
 
+  //binding color component to framebuffer technically only necessary for safari
+  const color = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, color);
+  gl.texImage2D(
+          gl.TEXTURE_2D,
+          0,
+          gl.RGBA,
+          depthTextureSize,
+          depthTextureSize,
+          0,
+          gl.RGBA,
+          gl.UNSIGNED_BYTE,
+          null,
+  );
+
+  gl.framebufferTexture2D(
+          gl.FRAMEBUFFER,
+          gl.COLOR_ATTACHMENT0,
+          gl.TEXTURE_2D,
+          color,
+          0,
+  );
+
   function degToRad(d) {
     return d * Math.PI / 180;
   }


### PR DESCRIPTION
In the current examples shadows will not work, because the depth texture is not rendered to.

According to the WebGL spec, a framebuffer might not be framebuffer complete if it only has a depth attachment. Most browsers seem to be fine with this, safari is not. I've added the color attachment to make it work, but I didn't add in a check for safari, just be sure it works everywhere and left a comment.