### PR TITLE
Prevent horizontal overflow

### DIFF
--- a/webgl/lessons/resources/index.css
+++ b/webgl/lessons/resources/index.css
@@ -1,6 +1,5 @@
 body {
   margin: 0;
-  width: 100vw;
 }
 .lesson-main>* {
     margin: 1em 0;


### PR DESCRIPTION
VW units do not account for scroll bar width, which causes overflow when used incorrectly.