### PR TITLE
Fix the typo

### DIFF
--- a/webgl/lessons/webgl-smallest-programs.md
+++ b/webgl/lessons/webgl-smallest-programs.md
@@ -60,7 +60,7 @@ You enable the scissor test with
 gl.enable(gl.SCISSOR_TEST);
 ```
 
-and then you set the scissor rectangle in pixels relative to the bottom right corner. It uses the same parameters
+and then you set the scissor rectangle in pixels relative to the bottom left corner. It uses the same parameters
 as `gl.viewport`.
 
 ```js


### PR DESCRIPTION
After my test, it seems to relative the bottom left corner.

Code:
```js
gl.enable(gl.SCISSOR_TEST);

gl.scissor(30, 10, 150, 75);
gl.clearColor(1, 1, 0, 1);
gl.clear(gl.COLOR_BUFFER_BIT);
```

Result:
<img width="318" alt="Screen Shot 2020-07-09 at 21 16 27" src="https://user-images.githubusercontent.com/22176164/87044415-0c0f5300-c229-11ea-8081-68b2964c9d39.png">
