### PR TITLE
fix: overflow issue in mobile

### DIFF
--- a/webgl/lessons/resources/lesson.css
+++ b/webgl/lessons/resources/lesson.css
@@ -64,7 +64,7 @@ pre.prettyprint code {
 }
 
 /* to handle long words in paragraph */
-p code {
+p, code, h3 {
   word-break: break-word;
   white-space: normal;
 }

--- a/webgl/lessons/resources/lesson.css
+++ b/webgl/lessons/resources/lesson.css
@@ -84,6 +84,7 @@ p code {
     margin: 0 auto 1em;
     max-width: 700px;
     width: calc(100% - 40px);
+    overflow-x: auto;
 }
 .lesson-main>.webgl_example_container {
     max-width: 90%;


### PR DESCRIPTION
There are some horizontal overflow issue in mobile(iPhone SE2).

### Fixing List

**overflow-x**
 - 2d-matrices
 - 3d-camera
 - drawing-multiple-things
 - data-textures
 - shadertoy
 - cross-platform-issues
 - readpixels

**word-break**
 - 3d-lighting-directional
 - attributes

### Some Captures

![2d-matrices](https://user-images.githubusercontent.com/20078201/111559430-d9642400-87d3-11eb-8b9d-b1cbb07cf68f.PNG)
![3d-camera](https://user-images.githubusercontent.com/20078201/111559434-da955100-87d3-11eb-9b37-2b1d457fe718.PNG)

