### PR TITLE
fix: img.src = url is missing  in line142

### DIFF
--- a/webgl/lessons/webgl-2d-drawimage.md
+++ b/webgl/lessons/webgl-2d-drawimage.md
@@ -139,7 +139,7 @@ Let's load some images into textures
         gl.bindTexture(gl.TEXTURE_2D, textureInfo.texture);
         gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, img);
       });
-
+      img.src = url;
       return textureInfo;
     }
 


### PR DESCRIPTION
Add ` img.src = url`  in line142