### PR TITLE
Correct usage of old code with slight LUT miscalculation

### DIFF
--- a/webgl/lessons/webgl-qna-how-to-simulate-a-3d-texture-in-webgl.md
+++ b/webgl/lessons/webgl-qna-how-to-simulate-a-3d-texture-in-webgl.md
@@ -61,22 +61,25 @@ Thanks in advance!
 You can simulate a 3d texture by storing each plane of the 3d texture in a 2d texture
 
 Then a function like this will let you use it as a 3d texture
-
-    vec4 sampleAs3DTexture(sampler2D tex, vec3 texCoord, float size) {
-        float sliceSize = 1.0 / size;                         // space of 1 slice
-        float slicePixelSize = sliceSize / size;              // space of 1 pixel
-        float sliceInnerSize = slicePixelSize * (size - 1.0); // space of size pixels
-        float zSlice0 = min(floor(texCoord.z * size), size - 1.0);
-        float zSlice1 = min(zSlice0 + 1.0, size - 1.0);
-        float xOffset = slicePixelSize * 0.5 + texCoord.x * sliceInnerSize;
-        float s0 = xOffset + (zSlice0 * sliceSize);
-        float s1 = xOffset + (zSlice1 * sliceSize);
-        vec4 slice0Color = texture2D(tex, vec2(s0, texCoord.y));
-        vec4 slice1Color = texture2D(tex, vec2(s1, texCoord.y));
-        float zOffset = mod(texCoord.z * size, 1.0);
-        return mix(slice0Color, slice1Color, zOffset);
-     }
-
+    
+    vec4 sampleAs3DTexture(sampler2D tex, vec3 texCoord, float size)
+    {
+    	float sliceSize = 1.0 / size;			 // space of 1 slice
+    	float slicePixelSize = sliceSize / size; // space of 1 pixel
+    	float width = size - 1.0;
+    	float sliceInnerSize = slicePixelSize * width; // space of size pixels
+    	float zSlice0 = floor(texCoord.z * width);
+    	float zSlice1 = min(zSlice0 + 1.0, width);
+    	float xOffset = slicePixelSize * 0.5 + texCoord.x * sliceInnerSize;
+    	float yRange = (texCoord.y * width + 0.5) / size;
+    	float s0 = xOffset + (zSlice0 * sliceSize);
+    	float s1 = xOffset + (zSlice1 * sliceSize);
+    	vec4 slice0Color = texture2D(tex, vec2(s0, yRange));
+    	vec4 slice1Color = texture2D(tex, vec2(s1, yRange));
+    	float zOffset = mod(texCoord.z * width, 1.0);
+    	return mix(slice0Color, slice1Color, zOffset);
+    }
+     
 If your 3d texture was 8x8x8 then you'd make a 2d texture that is 64x8 and put each plane of the 3d texture in your 2d texture. Then, knowing that was originally 8x8x8 you'd pass in `8.0` for the size to `sampleAs3DTexture`
 
     precision mediump float;
@@ -91,10 +94,9 @@ If your 3d texture was 8x8x8 then you'd make a 2d texture that is 64x8 and put e
       gl_FragColor = sampleAs3DTexture(u_my3DTexture, v_texCoord, CUBE_SIZE);
     }
 
-Note: the function above assumes you want bilinear filtering between the planes. If you don't you can simplify the function.
+Note: the function above assumes you want bilinear filtering between the planes. If you don't you can simplify the function, by returning `return texture2D(tex, vec2( s0, yRange));` immediately after calculating s0. 
 
-There's [a video explanation of this code here][1] which is from [this sample][2].
-
+There's [a video explanation of this code here][1] which is from [this sample][2]. The video explanation and the final code in the sample differ slightly. This is due to the code miscalculating LUT size and shifting all colors blue, which was corrected by the author in 2019.
 
   [1]: http://www.youtube.com/watch?v=rfQ8rKGTVlg#t=26m00s
   [2]: http://webglsamples.googlecode.com/hg/color-adjust/color-adjust.html


### PR DESCRIPTION
When [writing an article](https://blog.frost.kiwi/WebGL-LUTS-made-simple/) about the usage of LUTs in video games, I stumbled upon this QA article. Shown is a piece of code on how to emulate 3D Texture reads in WebGL 1.0, when no such function is present.

The code shown was outdated however, with a miscalculation on how the texture coordinates are accessed, leading to colors being blue-shifted. This was corrected by the original author of the code sample, @greggman [in 2019](https://github.com/WebGLSamples/WebGLSamples.github.io/commit/b07bf14b53c2666918ff8ae207a7588732012a2b), but the webglfundamentals article picked up the older version.

This PR corrects the code by replacing it with the newer version, which works flawlessly.