### PR TITLE
Replace broken shader URL

### DIFF
--- a/webgl/lessons/webgl-qna-can-anyone-explain-what-this-glsl-fragment-shader-is-doing-.md
+++ b/webgl/lessons/webgl-qna-can-anyone-explain-what-this-glsl-fragment-shader-is-doing-.md
@@ -4,7 +4,7 @@ TOC: Can anyone explain what this GLSL fragment shader is doing?
 
 ## Question:
 
-I realise this is a math-centric question but... if you look at this webpage (and have a good graphics card) http://mrdoob.github.com/three.js/examples/webgl_shader.html
+I realise this is a math-centric question but... if you look at [this webpage](https://threejs.org/examples/?q=shader#webgl_shader). (and have a good graphics card)
 
 If you look at the source, you'll notice a scary looking fragment shader.
 


### PR DESCRIPTION
Counterpart to: https://github.com/gfxfundamentals/webgl2-fundamentals/pull/227

> Replaced a broken link
> 
> Current:
> ![image](https://github.com/user-attachments/assets/460bf6c5-d8b2-45f7-b69b-983a000ce325)
> 
> New Link:
> ![image](https://github.com/user-attachments/assets/88cecdc1-24fe-461e-9893-c2e60553db83)
> 
> New URL:
> https://threejs.org/examples/?q=shader#webgl_shader